### PR TITLE
Check-only mode for dns updater

### DIFF
--- a/apps/dns/src/public_ip.py
+++ b/apps/dns/src/public_ip.py
@@ -1,6 +1,6 @@
 import logging
+import os
 import socket
-from os import environ
 
 import requests
 
@@ -35,14 +35,14 @@ def get_public_ip() -> str:
 
 
 def save_public_ip(public_ip: str) -> None:
-    log_path = environ["IP_HISTORY_PATH"]
+    log_path = os.environ["IP_HISTORY_PATH"]
     with open(log_path, "a") as ip_log:
         ip_log.write(public_ip + "\n")
     logging.info(f"Saved {public_ip} IP to the history file")
 
 
 def get_previous_public_ip() -> str:
-    log_path = environ["IP_HISTORY_PATH"]
+    log_path = os.environ["IP_HISTORY_PATH"]
     try:
         with open(log_path, "r") as ip_log:
             previous_ip = list(ip_log)[-1].strip()

--- a/apps/dns/src/update.py
+++ b/apps/dns/src/update.py
@@ -14,7 +14,7 @@ logging.basicConfig(
 
 if __name__ == '__main__':
     logging.info("Starting listening to Public IP changes")
-    check_only_mode = os.getenv("CHECK_ONLY_MODE", False)  # Setting CHECK_ONLY_MODE to any value is considered as True
+    check_only_mode = "CHECK_ONLY_MODE" in os.environ
     if check_only_mode:
         logging.info("CHECK_ONLY_MODE is enabled")
     killer = GracefulKiller()

--- a/apps/dns/src/update.py
+++ b/apps/dns/src/update.py
@@ -14,6 +14,9 @@ logging.basicConfig(
 
 if __name__ == '__main__':
     logging.info("Starting listening to Public IP changes")
+    check_only_mode = os.getenv("CHECK_ONLY_MODE", False)  # Setting CHECK_ONLY_MODE to any value is considered as True
+    if check_only_mode:
+        logging.info("CHECK_ONLY_MODE is enabled")
     killer = GracefulKiller()
     while not killer.kill_now:
         current_ip = public_ip.get_public_ip()
@@ -34,11 +37,11 @@ if __name__ == '__main__':
             continue
 
         dns_handler = HandlerDNS(public_ip=current_ip)
-        if os.getenv("CHECK_ONLY_MODE", False):
+        if not check_only_mode:
+            update_success = dns_handler.update_dns_entry()
+        else:
             logging.info("CHECK_ONLY_MODE: Skipping update")
             update_success = True
-        else:
-            update_success = dns_handler.update_dns_entry()
         if update_success:
             public_ip.save_public_ip(public_ip=current_ip)
             time.sleep(600)

--- a/manifests/base/dns-updater/dns-updater.yaml
+++ b/manifests/base/dns-updater/dns-updater.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: updater
-          image: theadzik/dnsupdater:3.2.6
+          image: theadzik/dnsupdater:2024.02.1
           imagePullPolicy: Always
           envFrom:
             - secretRef:

--- a/manifests/overlay/dev/kustomization.yaml
+++ b/manifests/overlay/dev/kustomization.yaml
@@ -34,3 +34,17 @@ patches:
         name: vaultwarden
         annotations:
           cert-manager.io/cluster-issuer: "lets-encrypt-staging"
+
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: dns-updater
+      spec:
+        template:
+          spec:
+            containers:
+              - name: updater
+                env:
+                  - name: CHECK_ONLY_MODE
+                    value: "True"


### PR DESCRIPTION
* DNS updater can now be set in CHECK_ONLY_MODE by setting the env var.