### PR TITLE
Fix for code scanning alert no. 36: Incomplete regular expression for hostnames

### DIFF
--- a/.github/scripts/sync-waves-inventory/main.py
+++ b/.github/scripts/sync-waves-inventory/main.py
@@ -20,7 +20,7 @@ for filename in kustomization["resources"]:
     application_file = open(search_path + filename, "r")
     sync_priority = 0
     for line in application_file:
-        if re.search("argocd.argoproj.io/sync-wave", line):
+        if re.search(r"argocd\.argoproj\.io/sync-wave", line):
             sync_priority = int(re.search("(-|)[0-9]+", line).group(0))
             break
 


### PR DESCRIPTION
Potential fix for [https://github.com/theadzik/homelab/security/code-scanning/36](https://github.com/theadzik/homelab/security/code-scanning/36)

To fix the issue, the `.` characters in the regular expression should be escaped with a backslash (`\`) to ensure they are treated as literal dots rather than meta-characters. This will make the regex match only the exact string `argocd.argoproj.io/sync-wave` and not any unintended variations. The change should be made on line 23 where the regex is used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
