### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backup-build.yaml
+++ b/.github/workflows/backup-build.yaml
@@ -1,6 +1,5 @@
 name: vw-backup-build
-permissions:
-  contents: read
+
 on:
   push:
     tags:
@@ -8,6 +7,9 @@ on:
   schedule:
     - cron: "37 10 * * 6"
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   get-tag:

--- a/.github/workflows/restore-build.yaml
+++ b/.github/workflows/restore-build.yaml
@@ -1,4 +1,5 @@
 name: vw-restore-build
+
 on:
   push:
     tags:

--- a/.sec.baseline
+++ b/.sec.baseline
@@ -139,7 +139,7 @@
         "filename": ".github/workflows/backup-build.yaml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 28,
         "is_secret": false
       }
     ],
@@ -149,7 +149,7 @@
         "filename": ".github/workflows/restore-build.yaml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 28,
         "is_secret": false
       }
     ],
@@ -378,5 +378,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-14T15:51:14Z"
+  "generated_at": "2025-12-15T20:59:15Z"
 }


### PR DESCRIPTION
Potential fix for [https://github.com/theadzik/homelab/security/code-scanning/39](https://github.com/theadzik/homelab/security/code-scanning/39)

To fix the problem, you should explicitly set the `permissions` setting at the root level of the workflow file (`.github/workflows/restore-build.yaml`). This setting applies to all jobs unless they specify their own `permissions`. For maximum safety and to adhere to the principle of least privilege, set `permissions` to `read-all` (or the YAML equivalent `contents: read` if you want to be more granular) unless any jobs require additional permissions. If the jobs do not perform writes to the repository, read-only is usually sufficient. Add the `permissions:` block immediately after the workflow name but before `on:` or immediately after the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
