### PR TITLE
chore: traefik to 39.x, remove crds chart

### DIFF
--- a/kubernetes/bootstrap/charts/app-of-apps/templates/traefik.yaml
+++ b/kubernetes/bootstrap/charts/app-of-apps/templates/traefik.yaml
@@ -14,7 +14,7 @@ spec:
       targetRevision: 39.*.*
       helm:
         releaseName: traefik
-        skipCrds: true
+        skipCrds: false
         valueFiles:
           - $repo/kubernetes/helm/traefik/values.yaml
     - repoURL: {{ .Values.spec.sources.repoURL }}

--- a/kubernetes/bootstrap/charts/app-of-apps/templates/traefik.yaml
+++ b/kubernetes/bootstrap/charts/app-of-apps/templates/traefik.yaml
@@ -1,34 +1,6 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: traefik-crds
-  annotations:
-    argocd.argoproj.io/sync-wave: "-30"
-spec:
-  project: default
-  sources:
-    - path: .
-      repoURL: oci://ghcr.io/traefik/helm/traefik-crds
-      targetRevision: 1.*.*
-      helm:
-        releaseName: traefik-crds
-  destination:
-    server: "https://kubernetes.default.svc"
-    namespace: traefik
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    syncOptions:
-      - PruneLast=true
-    retry:
-      limit: -1
-
----
-
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
   name: traefik
   annotations:
     argocd.argoproj.io/sync-wave: "-25"
@@ -39,7 +11,7 @@ spec:
   sources:
     - path: .
       repoURL: oci://ghcr.io/traefik/helm/traefik
-      targetRevision: 37.*.*
+      targetRevision: 39.*.*
       helm:
         releaseName: traefik
         skipCrds: true

--- a/kubernetes/helm/traefik/values.yaml
+++ b/kubernetes/helm/traefik/values.yaml
@@ -58,11 +58,12 @@ ports:
         - 131.0.72.0/22
     proxyProtocol:
       trustedIPs: *trustedIPs
-    redirections:
-      entryPoint:
-        to: websecure
-        scheme: https
-        permanent: true
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
   websecure:
     forwardedHeaders:
       trustedIPs: *trustedIPs


### PR DESCRIPTION
This pull request updates the configuration for the Traefik deployment in our Kubernetes cluster. The main changes involve removing the separate Traefik CRDs application, updating the Traefik chart version, and modifying the Traefik Helm values to adjust HTTP redirection settings.

**ArgoCD Application Configuration:**

* Removed the separate `traefik-crds` ArgoCD `Application` resource from `traefik.yaml`, consolidating the setup to rely on the main Traefik chart with CRDs skipped.
* Updated the main Traefik Helm chart version from `37.*.*` to `39.*.*` in `traefik.yaml` for improved features and bug fixes.

**Traefik Helm Values:**

* Added an `http` section under `entryPoints` in `values.yaml` to explicitly configure HTTP-to-HTTPS redirection, improving security by ensuring all HTTP traffic is redirected to HTTPS.