### PR TITLE
chore: bump cnpg chart version

### DIFF
--- a/kubernetes/bootstrap/charts/app-of-apps/templates/tandoor.yaml
+++ b/kubernetes/bootstrap/charts/app-of-apps/templates/tandoor.yaml
@@ -10,7 +10,7 @@ spec:
   sources:
     - chart: cluster
       repoURL: https://cloudnative-pg.github.io/charts
-      targetRevision: 0.3.*
+      targetRevision: 0.6.*
       helm:
         releaseName: database
         valueFiles:


### PR DESCRIPTION
This pull request updates the `tandoor.yaml` Helm chart configuration to use a newer version of the `cluster` chart. The only change is updating the `targetRevision` field to ensure the deployment uses the `0.6.*` version series instead of `0.3.*`.

- Updated the `targetRevision` for the `cluster` chart from `0.3.*` to `0.6.*` in `tandoor.yaml` to deploy a newer version of the chart.