### PR TITLE
fix: Enable tls for argocd

### DIFF
--- a/kubernetes/helm/argocd/values.yaml
+++ b/kubernetes/helm/argocd/values.yaml
@@ -21,13 +21,13 @@ global:
 
   networkPolicy:
     create: true
-    defaultDenyIngress: false
+    defaultDenyIngress: true
 
   priorityClassName: "system-cluster-critical"
 
 configs:
   params:
-    server.insecure: true
+    server.insecure: false
   rbac:
     policy.csv: |
       p, role:authenticated, *, *, *, deny
@@ -40,11 +40,18 @@ server:
   ingress:
     enabled: true
     annotations:
-      cert-manager.io/cluster-issuer: "lets-encrypt-prod"
+      traefik.ingress.kubernetes.io/service.serversscheme: https
     labels:
       dns-type: internal
     ingressClassName: "traefik"
     tls: true
+  certificate:
+    enabled: true
+    secretName: argocd-server-tls
+    issuer:
+      name: lets-encrypt-prod
+      kind: ClusterIssuer
+    domain: argocd.zmuda.pro
 
 repoServer:
   env:


### PR DESCRIPTION
This pull request makes several important security and configuration improvements to the ArgoCD Helm chart. The changes focus on tightening network policies, improving server security, and updating ingress and TLS certificate management.

Security and network policy enhancements:

* Set `networkPolicy.defaultDenyIngress` to `true` to deny all ingress traffic by default, improving the security posture of the deployment.
* Set `configs.params.server.insecure` to `false`, disabling insecure server mode for ArgoCD.

Ingress and TLS configuration updates:

* Replaced the ingress annotation for certificate management to use Traefik's HTTPS scheme instead of cert-manager, aligning with the ingress controller in use.
* Added a new `certificate` section under `server` to enable automatic TLS certificate provisioning, specifying the secret name, issuer details, and domain for ArgoCD.