### PR TITLE
feat: vaultwarden dhi

### DIFF
--- a/apps/vaultwarden/backup/Dockerfile
+++ b/apps/vaultwarden/backup/Dockerfile
@@ -1,7 +1,4 @@
-FROM alpine:3.24.1
-
-ARG USER_ID=1000
-ARG GROUP_ID=1000
+FROM dhi.io/alpine-base:3.24-dev AS build
 
 RUN apk add --no-cache \
     openssl \
@@ -9,10 +6,14 @@ RUN apk add --no-cache \
     tar \
     sqlite
 
-RUN addgroup --gid $GROUP_ID --system vaultwarden && \
-    adduser --uid $USER_ID --system --ingroup vaultwarden --disabled-password --gecos "" vaultwarden
+FROM dhi.io/alpine-base:3.24
 
-COPY --chown=vaultwarden:vaultwarden --chmod=755 backup.sh /backup.sh
-USER vaultwarden:vaultwarden
+COPY --from=build /usr/lib/ /usr/lib/
+COPY --from=build /usr/bin/openssl /usr/bin/openssl
+COPY --from=build /usr/bin/rclone /usr/bin/rclone
+COPY --from=build /usr/bin/tar /usr/bin/tar
+COPY --from=build /usr/bin/sqlite3 /usr/bin/sqlite3
 
+COPY --chown=nonroot:nonroot --chmod=755 backup.sh /backup.sh
+USER nonroot
 ENTRYPOINT ["/backup.sh"]

--- a/apps/vaultwarden/backup/Dockerfile
+++ b/apps/vaultwarden/backup/Dockerfile
@@ -1,8 +1,9 @@
+FROM rclone/rclone:1.74.3 AS rclone
+
 FROM dhi.io/alpine-base:3.24-dev AS build
 
 RUN apk add --no-cache \
     openssl \
-    rclone \
     tar \
     sqlite
 
@@ -10,9 +11,9 @@ FROM dhi.io/alpine-base:3.24
 
 COPY --from=build /usr/lib/ /usr/lib/
 COPY --from=build /usr/bin/openssl /usr/bin/openssl
-COPY --from=build /usr/bin/rclone /usr/bin/rclone
-COPY --from=build /usr/bin/tar /usr/bin/tar
+COPY --from=build /bin/tar /usr/bin/tar
 COPY --from=build /usr/bin/sqlite3 /usr/bin/sqlite3
+COPY --from=rclone /usr/local/bin/rclone /usr/bin/rclone
 
 COPY --chown=nonroot:nonroot --chmod=755 backup.sh /backup.sh
 USER nonroot

--- a/apps/vaultwarden/restore/Dockerfile
+++ b/apps/vaultwarden/restore/Dockerfile
@@ -1,8 +1,9 @@
+FROM rclone/rclone:1.74.3 AS rclone
+
 FROM dhi.io/alpine-base:3.24-dev AS build
 
 RUN apk add --no-cache \
     openssl \
-    rclone \
     tar \
     sqlite
 
@@ -10,9 +11,9 @@ FROM dhi.io/alpine-base:3.24
 
 COPY --from=build /usr/lib/ /usr/lib/
 COPY --from=build /usr/bin/openssl /usr/bin/openssl
-COPY --from=build /usr/bin/rclone /usr/bin/rclone
-COPY --from=build /usr/bin/tar /usr/bin/tar
+COPY --from=build /bin/tar /usr/bin/tar
 COPY --from=build /usr/bin/sqlite3 /usr/bin/sqlite3
+COPY --from=rclone /usr/local/bin/rclone /usr/bin/rclone
 
 COPY --chown=nonroot:nonroot --chmod=755 restore.sh /restore.sh
 USER nonroot

--- a/apps/vaultwarden/restore/Dockerfile
+++ b/apps/vaultwarden/restore/Dockerfile
@@ -1,7 +1,4 @@
-FROM alpine:3.24.1
-
-ARG USER_ID=1000
-ARG GROUP_ID=1000
+FROM dhi.io/alpine-base:3.24-dev AS build
 
 RUN apk add --no-cache \
     openssl \
@@ -9,10 +6,14 @@ RUN apk add --no-cache \
     tar \
     sqlite
 
-RUN addgroup --gid $GROUP_ID --system vaultwarden && \
-    adduser --uid $USER_ID --system --ingroup vaultwarden --disabled-password --gecos "" vaultwarden
+FROM dhi.io/alpine-base:3.24
 
-COPY --chown=vaultwarden:vaultwarden --chmod=755 restore.sh /restore.sh
-USER vaultwarden:vaultwarden
+COPY --from=build /usr/lib/ /usr/lib/
+COPY --from=build /usr/bin/openssl /usr/bin/openssl
+COPY --from=build /usr/bin/rclone /usr/bin/rclone
+COPY --from=build /usr/bin/tar /usr/bin/tar
+COPY --from=build /usr/bin/sqlite3 /usr/bin/sqlite3
 
+COPY --chown=nonroot:nonroot --chmod=755 restore.sh /restore.sh
+USER nonroot
 ENTRYPOINT ["/restore.sh"]

--- a/kubernetes/kustomizations/vaultwarden/backup-cronjob.yaml
+++ b/kubernetes/kustomizations/vaultwarden/backup-cronjob.yaml
@@ -62,6 +62,7 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
             fsGroup: 1000
+            fsGroupChangePolicy: "OnRootMismatch"
             seccompProfile:
               type: RuntimeDefault
           volumes:


### PR DESCRIPTION
This pull request refactors the Dockerfiles for the Vaultwarden backup and restore containers to improve image layering, security, and maintainability. It also updates the Kubernetes CronJob spec to enhance filesystem group handling.

**Dockerfile refactoring and security improvements:**

* Both `apps/vaultwarden/backup/Dockerfile` and `apps/vaultwarden/restore/Dockerfile` now use a multi-stage build, separating the installation of dependencies and the inclusion of the `rclone` binary, and switch from the custom `vaultwarden` user to a standard `nonroot` user for improved security. [[1]](diffhunk://#diff-a20699b9668cf830f6d726371b5c82735f968e17a848174a1ff1e3287518a3f8L1-R19) [[2]](diffhunk://#diff-9575e30601bce7babd53f8547eee5a302cb734e03716384c114801ea6731ec64L1-R19)
* The new Dockerfiles copy only the necessary binaries from the build and `rclone` stages, reducing image size and attack surface. [[1]](diffhunk://#diff-a20699b9668cf830f6d726371b5c82735f968e17a848174a1ff1e3287518a3f8L1-R19) [[2]](diffhunk://#diff-9575e30601bce7babd53f8547eee5a302cb734e03716384c114801ea6731ec64L1-R19)
* User and group creation via build arguments has been removed in favor of the `nonroot` user, simplifying user management. [[1]](diffhunk://#diff-a20699b9668cf830f6d726371b5c82735f968e17a848174a1ff1e3287518a3f8L1-R19) [[2]](diffhunk://#diff-9575e30601bce7babd53f8547eee5a302cb734e03716384c114801ea6731ec64L1-R19)

**Kubernetes CronJob improvement:**

* The `kubernetes/kustomizations/vaultwarden/backup-cronjob.yaml` spec now sets `fsGroupChangePolicy: "OnRootMismatch"` to optimize how filesystem group ownership is applied, which can improve performance and compatibility with certain storage backends.