### PR TITLE
SSDLC phase 2b: publish tags after attestations

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -70,14 +70,19 @@ jobs:
           tags: |
             type=raw,value=${{ inputs.docker-tag }}
 
-      - name: Build and Push
+      # When publishing, push by digest with no tags: ArgoCD Image Updater finds
+      # images by listing tags, so a tag published here - before the attestations
+      # below exist - lets a deployment race its own attestation upload. The
+      # Kyverno policy now denies rather than warns, so that race would reject
+      # the pod. Tags are applied in the final step instead. When not publishing
+      # (Dependabot PRs) this is a build-only validation.
+      - name: Build and push by digest
         id: build-push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: "${{ inputs.context-path }}"
           platforms: "linux/amd64"
-          push: ${{ inputs.push }}
-          tags: ${{ steps.meta.outputs.tags }}
+          outputs: ${{ inputs.push && format('type=image,name={0}/{1}/{2},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY, env.REPOSITORY, env.IMAGE_NAME) || 'type=cacheonly' }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=gha
@@ -112,3 +117,28 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build-push.outputs.digest }}
           push-to-registry: true
+
+      # Only now does the image become discoverable, with its attestations
+      # already in place. `imagetools create` re-pushes the same manifest under
+      # each tag rather than wrapping it in a new index, so the digest is
+      # unchanged and the attestations - attached to that digest - stay findable.
+      # Verified against a scratch registry before relying on it.
+      - name: Publish tags
+        if: inputs.push
+        env:
+          METADATA_JSON: ${{ steps.meta.outputs.json }}
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build-push.outputs.digest }}
+        run: |-
+          set -euo pipefail
+          args=()
+          while IFS= read -r tag; do
+            args+=(--tag "$tag")
+          done < <(jq -r '.tags[]' <<< "$METADATA_JSON")
+
+          if [[ ${#args[@]} -eq 0 ]]; then
+            echo "::error title=Publish tags::docker/metadata-action produced no tags"
+            exit 1
+          fi
+
+          docker buildx imagetools create "${args[@]}" "${IMAGE_REF}@${DIGEST}"


### PR DESCRIPTION
Closes the push-to-attest race in this repo. Same change as theadzik/blog#109, and it matters here for the same reason: the Kyverno `ImageValidatingPolicy` globs `theadzik/*`, so **vw-backup, vw-restore and custom-argocd** are all subject to the `Deny` that phase 2 turned on.

## The problem

The image was pushed with its final tag and attested seconds later. ArgoCD Image Updater discovers images by **listing tags**, so it could adopt one inside that window and deploy it before any attestation existed.

This is visible in cluster history: all five ArgoCD control-plane pods carried stale `fail` verdicts dated 2026-06-30, yet `custom-argocd:v3.4.4` verifies correctly today. They were admitted mid-race, and the verdict froze because background evaluation was off.

Under `Warn` that was cosmetic. Under `Deny` the same race **rejects the pod**, and the deployment only recovers via ArgoCD's retry backoff.

## The fix

**Push by digest (no tags) → attest → publish tags.** The image becomes discoverable only once it can be verified.

This relies on tagging not changing the digest, since attestations attach to the digest rather than the tag. `imagetools create` re-pushes the same manifest instead of wrapping it in a new index. Verified against a scratch local registry rather than assumed, and rather than experimenting against the real repository:

```
push-by-digest    -> tags: null              (invisible to Image Updater)
imagetools create -> tags: [main, sha-abc1234]
  both tags return a docker-content-digest identical to the original
```

## Unchanged behaviour

Build-only runs (Dependabot pull requests) take `type=cacheonly` and skip the attestation and tagging steps, exactly as before.

## Note for reviewers

This changes how every image in this repo reaches the registry - vw-backup, vw-restore and custom-argocd included. If `Publish tags` fails after a successful push, the image exists at a digest with no tag; recoverable by re-running the step, but it will not look like a normal build failure.

Merge alongside or after theadzik/blog#109. Leaving one repo on the old flow is not harmful, only inconsistent.