### PR TITLE
fix(kyverno): authenticate to Docker Hub when verifying images

### DIFF
--- a/kubernetes/kustomizations/kyverno/validate-image-attestations.yaml
+++ b/kubernetes/kustomizations/kyverno/validate-image-attestations.yaml
@@ -3,52 +3,15 @@ kind: ImageValidatingPolicy
 metadata:
   name: validate-image-attestations
 spec:
-  # Without this the cosign verifier talks to Docker Hub anonymously and gets
-  # rate limited, even though every controller already runs with
-  # --imagePullSecrets=dockerhub-image-pull-secret. That flag configures
-  # Kyverno's own registry client; the ImageValidatingPolicy cosign path takes
-  # its credentials from here instead, and silently falls back to anonymous when
-  # this is unset.
-  #
-  # Measured: Kyverno logged 429 for zmuda-pro-blog:2026.7.5 at 2026-07-31
-  # 04:02:10Z, while the theadzik account bucket read 199/200 remaining minutes
-  # later. Its requests were never being billed to the account at all - they
-  # were hitting the anonymous per-IP bucket, which is half the size (100/hour
-  # vs 200/hour) and shared with every other anonymous pull leaving the cluster.
-  #
-  # The secret must live in the Kyverno namespace, which this one already does.
   credentials:
     secrets:
       - dockerhub-image-pull-secret
   webhookConfiguration:
     timeoutSeconds: 30
-  # Fail open when the policy cannot be *evaluated*, fail closed when an image
-  # actually fails verification. These are separate concerns and separate fields:
-  # failurePolicy covers CEL/runtime errors - which in practice means Docker Hub
-  # returning 429 against this account's 200-request/hour budget - while
-  # validationActions below covers an image that genuinely does not verify.
-  # With Fail, a registry hiccup would stop every theadzik/* pod from starting,
-  # including ArgoCD's own, which is what would be needed to undo it.
   failurePolicy: Ignore
   evaluation:
     background:
-      # Re-evaluate already-running pods, not just admission. Catches an image
-      # whose signature stops verifying after it was admitted (revocation, or a
-      # tag repointed under a running workload).
       enabled: true
-  # Enforcing. Everything needed was already in place - keyless cosign identity
-  # bound to the build workflow, SBOM and provenance attestations, Rekor - and
-  # Warn meant an unsigned or tampered image was admitted with a message nobody
-  # reads.
-  #
-  # Safe to turn on now because the reports were re-checked once background
-  # evaluation landed: 73 pass, 0 fail. The seven earlier "failures" were stale
-  # verdicts frozen at admission time, from pods that raced their own
-  # attestation upload; all of those images verify correctly today.
-  #
-  # Audit rather than Warn alongside Deny: the two are mutually exclusive per the
-  # API ("Deny and Warn may not be used together"). Audit keeps PolicyReports
-  # recording every decision.
   validationActions:
     - Deny
     - Audit

--- a/kubernetes/kustomizations/kyverno/validate-image-attestations.yaml
+++ b/kubernetes/kustomizations/kyverno/validate-image-attestations.yaml
@@ -3,6 +3,23 @@ kind: ImageValidatingPolicy
 metadata:
   name: validate-image-attestations
 spec:
+  # Without this the cosign verifier talks to Docker Hub anonymously and gets
+  # rate limited, even though every controller already runs with
+  # --imagePullSecrets=dockerhub-image-pull-secret. That flag configures
+  # Kyverno's own registry client; the ImageValidatingPolicy cosign path takes
+  # its credentials from here instead, and silently falls back to anonymous when
+  # this is unset.
+  #
+  # Measured: Kyverno logged 429 for zmuda-pro-blog:2026.7.5 at 2026-07-31
+  # 04:02:10Z, while the theadzik account bucket read 199/200 remaining minutes
+  # later. Its requests were never being billed to the account at all - they
+  # were hitting the anonymous per-IP bucket, which is half the size (100/hour
+  # vs 200/hour) and shared with every other anonymous pull leaving the cluster.
+  #
+  # The secret must live in the Kyverno namespace, which this one already does.
+  credentials:
+    secrets:
+      - dockerhub-image-pull-secret
   webhookConfiguration:
     timeoutSeconds: 30
   # Fail open when the policy cannot be *evaluated*, fail closed when an image


### PR DESCRIPTION
Image verification has been talking to Docker Hub **anonymously**, so it was rate limited against the wrong bucket while the paid-for account budget sat idle.

## How it surfaced

The `backgroundScanInterval: 1h -> 24h` change ~10h ago was expected to stop the 429s. It did cut request volume, but new errors kept appearing at **admission** time - `blog-dev` at 23:52Z, `vw-backup` at 00:01Z. So volume was never the constraint.

The contradiction that gave it away - Kyverno logged this at `04:02:10Z`:

```
image verification failed ...
  GET .../theadzik/zmuda-pro-blog/manifests/2026.7.5: unexpected status code 429 Too Many Requests
```

while a probe minutes later showed the account bucket essentially full:

```
docker-ratelimit-source: theadzik
ratelimit-limit:     200;w=3600
ratelimit-remaining: 199;w=3600
```

Both cannot describe the same bucket. The requests were hitting the **anonymous per-IP** limit - half the size (100/hour vs 200/hour) and shared with every other anonymous pull leaving the cluster.

## Why the existing flag was not enough

All four controllers already run with `--imagePullSecrets=dockerhub-image-pull-secret`, and the reports-controller logs `setup registry client ... secrets=dockerhub-image-pull-secret`. But that flag configures Kyverno's *own* registry client. The `ImageValidatingPolicy` cosign path reads credentials from `spec.credentials`, and falls back to anonymous when unset - without warning. Setting it moves the traffic onto the account bucket.

The secret must live in the Kyverno namespace; `dockerhub-image-pull-secret` already does.

## Ruled out first

| Suspect | Verdict |
| --- | --- |
| ArgoCD Image Updater | Measured over 3 minutes: `remaining` went 199 -> 197, and 4 of those were my own probes. Only 4 of its 20 tracked images are on Docker Hub; the rest are lscr.io, registry.k8s.io, ghcr.io. Tag listing is not billed as a pull. |
| trivy-operator | Zero vulnerability reports; its node-collector has been failing for 31 days. Not scanning at all. |
| Background scan volume | Already reduced to daily; 429s continued at admission afterwards. |

## Left unchanged

`backgroundScanInterval` stays at `24h`. Daily re-verification is ample, and it leaves headroom now that requests are billed correctly.

## Verification

`kustomize build` clean; `kubectl apply --dry-run=server` accepts the policy.

After merge, the check is that **new** 429 errors stop appearing - the 13 existing error verdicts are frozen snapshots and will clear on the next daily background scan.