### PR TITLE
ci: pin the shared workflow to v2.0.0-rc

### DIFF
--- a/.github/workflows/backup-build.yaml
+++ b/.github/workflows/backup-build.yaml
@@ -21,7 +21,7 @@ jobs:
     with:
       tag-prefix: "vw-backup-"
   backup-build-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@94086bb6b9c07ff6c9a073e0ac79c24415ec18ed # v1.1.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@454a41dd5740cf83df3dc54f2ff5281591f9f100 # v2.0.0-rc
     needs: get-tag
     permissions:
       contents: read

--- a/.github/workflows/backup-build.yaml
+++ b/.github/workflows/backup-build.yaml
@@ -21,7 +21,7 @@ jobs:
     with:
       tag-prefix: "vw-backup-"
   backup-build-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@454a41dd5740cf83df3dc54f2ff5281591f9f100 # v2.0.0-rc
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1da8cf0325767a1bae37c18cc3cdb0ba9c9a6f48 # v2.0.0-rc.2
     needs: get-tag
     permissions:
       contents: read

--- a/.github/workflows/backup-build.yaml
+++ b/.github/workflows/backup-build.yaml
@@ -21,7 +21,7 @@ jobs:
     with:
       tag-prefix: "vw-backup-"
   backup-build-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@a75831dcde77fb4ad7caa180497a48fd0be072c4 # v1.0.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@94086bb6b9c07ff6c9a073e0ac79c24415ec18ed # v1.1.0
     needs: get-tag
     permissions:
       contents: read

--- a/.github/workflows/custom-argocd.yaml
+++ b/.github/workflows/custom-argocd.yaml
@@ -51,7 +51,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@a75831dcde77fb4ad7caa180497a48fd0be072c4 # v1.0.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@94086bb6b9c07ff6c9a073e0ac79c24415ec18ed # v1.1.0
     with:
       git-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
       tags: "type=raw,value=${{ needs.get-version.outputs.app_version }}"

--- a/.github/workflows/custom-argocd.yaml
+++ b/.github/workflows/custom-argocd.yaml
@@ -51,7 +51,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@454a41dd5740cf83df3dc54f2ff5281591f9f100 # v2.0.0-rc
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1da8cf0325767a1bae37c18cc3cdb0ba9c9a6f48 # v2.0.0-rc.2
     with:
       git-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
       tags: "type=raw,value=${{ needs.get-version.outputs.app_version }}"

--- a/.github/workflows/custom-argocd.yaml
+++ b/.github/workflows/custom-argocd.yaml
@@ -51,7 +51,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@94086bb6b9c07ff6c9a073e0ac79c24415ec18ed # v1.1.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@454a41dd5740cf83df3dc54f2ff5281591f9f100 # v2.0.0-rc
     with:
       git-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
       tags: "type=raw,value=${{ needs.get-version.outputs.app_version }}"

--- a/.github/workflows/restore-build.yaml
+++ b/.github/workflows/restore-build.yaml
@@ -21,7 +21,7 @@ jobs:
     with:
       tag-prefix: "vw-restore-"
   restore-build-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@454a41dd5740cf83df3dc54f2ff5281591f9f100 # v2.0.0-rc
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1da8cf0325767a1bae37c18cc3cdb0ba9c9a6f48 # v2.0.0-rc.2
     needs: get-tag
     permissions:
       contents: read

--- a/.github/workflows/restore-build.yaml
+++ b/.github/workflows/restore-build.yaml
@@ -21,7 +21,7 @@ jobs:
     with:
       tag-prefix: "vw-restore-"
   restore-build-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@94086bb6b9c07ff6c9a073e0ac79c24415ec18ed # v1.1.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@454a41dd5740cf83df3dc54f2ff5281591f9f100 # v2.0.0-rc
     needs: get-tag
     permissions:
       contents: read

--- a/.github/workflows/restore-build.yaml
+++ b/.github/workflows/restore-build.yaml
@@ -21,7 +21,7 @@ jobs:
     with:
       tag-prefix: "vw-restore-"
   restore-build-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@a75831dcde77fb4ad7caa180497a48fd0be072c4 # v1.0.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@94086bb6b9c07ff6c9a073e0ac79c24415ec18ed # v1.1.0
     needs: get-tag
     permissions:
       contents: read


### PR DESCRIPTION
Follow-up to #330, which moved these three callers onto
[`theadzik/github-workflows`](https://github.com/theadzik/github-workflows). This repins
them from v1.0.0 to **v2.0.0-rc** — a release candidate, pinned here deliberately: this
repo builds three images on every pull request, so it is where the new flow gets
exercised before anything is tagged stable.

## What v2 changes

v1 pushed the image by digest and then scanned what it had pushed. The gate held — an
untagged, unsigned, unattested digest is not deployable — but the vulnerable bytes were
in the registry either way, and Docker Hub does not make removing them easy.

v2 builds into an OCI layout on disk, scans it there, and only pushes if the scan passes:

```text
build → OCI layout → Trivy → push by digest (no tag)
      → cosign sign → attest SBOM → attest provenance → cosign verify → publish tags
```

Pushing a layout without writing a tag needs `regctl` — `docker buildx imagetools create`
refuses to run without `--tag`, and skopeo rejects a digest destination. Verified against
a scratch registry: the manifest lands at the same digest with the attestation manifest
intact, and `tags/list` stays empty, which is the property the buildkit exporter provided.

v1.1.0 (never merged here) also added `cosign sign` and a `cosign verify` gate before
tags publish, since `actions/attest` only signs statements *about* an image and
[`validate-image-attestations.yaml`](kubernetes/kustomizations/kyverno/validate-image-attestations.yaml)
opens with `verifyImageSignatures(...) > 0`. That is included here.

Inputs are unchanged, so this is a pin change only. The three callers keep `scan: false` —
their findings are all inside `rclone` and the argocd binary, copied from upstream images.

## What this PR proves, and what it does not

The runs on this PR confirm the OCI layout export works on a runner and that the digest is
read back from `index.json`:

```text
#20 exporting to oci image format
#20 exporting manifest sha256:8cbbf7dbc492f7fc4807c04c235e96054664fbbf0e6fb637d562b445915f462b done
Built sha256:8cbbf7dbc492f7fc4807c04c235e96054664fbbf0e6fb637d562b445915f462b
```

Not exercised here:

- **The Trivy-on-layout step**, because all three callers set `scan: false`. It was
  verified locally instead, by replaying the action's entrypoint against trivy v0.70.0 —
  the version it pins — on a real layout directory: exit 1 with findings, exit 0 without.
  Setting `scan: true` with `scan-severity: CRITICAL` on one caller would cover it in CI
  and still pass, since these images have 0 fixable CRITICAL findings. Say the word.
- **Push, signature, attestation and tagging**, since PR runs use `push: false`. Those
  first execute on a tag push or the weekly rebuild after merge.

Open items are tracked in
[workflows-issues.md](https://github.com/theadzik/github-workflows/blob/main/workflows-issues.md):
whether Kyverno 1.18.2 accepts the Sigstore bundle cosign 3.x writes to the
`sha256-<digest>` tag, and the fact that the policy is currently erroring on every
`theadzik/*` image with Docker Hub 429s, which `failurePolicy: Ignore` turns into silent
admission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)