### PR TITLE
ci: build images on ghcr.io with shared workflow v2.1.0

### DIFF
--- a/.github/workflows/backup-build.yaml
+++ b/.github/workflows/backup-build.yaml
@@ -38,7 +38,7 @@ jobs:
       image-name: "${{ github.repository_owner }}/vw-backup"
       registry-username: ${{ github.actor }}
       extra-registry: dhi.io
-      extra-registry-username: ${{ vars.DOCKERHUB_USERNAME }}
+      extra-registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
       context-path: "apps/vaultwarden/backup"
       # The shared workflow scans by default. Every finding here is inside the
       # rclone binary copied from rclone/rclone, in rclone's own Go

--- a/.github/workflows/backup-build.yaml
+++ b/.github/workflows/backup-build.yaml
@@ -21,19 +21,24 @@ jobs:
     with:
       tag-prefix: "vw-backup-"
   backup-build-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@a75831dcde77fb4ad7caa180497a48fd0be072c4 # v1.0.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1d7be13ba716c8f074a22d26eb8cfa7b032d00e8 # v2.1.0
     needs: get-tag
     permissions:
       contents: read
       id-token: write
       attestations: write
       artifact-metadata: write
+      packages: write
     with:
       # A pull request must build its own head, not the last released tag,
       # or the Dockerfile change under review is never actually exercised.
       git-ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || needs.get-tag.outputs.git_tag }}
       tags: "type=raw,value=${{ needs.get-tag.outputs.docker_tag }}"
-      image-name: "vw-backup"
+      registry: ghcr.io
+      image-name: "${{ github.repository_owner }}/vw-backup"
+      registry-username: ${{ github.actor }}
+      extra-registry: dhi.io
+      extra-registry-username: ${{ vars.DOCKERHUB_USERNAME }}
       context-path: "apps/vaultwarden/backup"
       # The shared workflow scans by default. Every finding here is inside the
       # rclone binary copied from rclone/rclone, in rclone's own Go
@@ -42,4 +47,6 @@ jobs:
       # rebuild can - so the gate would block the weekly rebuild indefinitely.
       scan: false
       push: ${{ github.event_name != 'pull_request' }}
-    secrets: inherit
+    secrets:
+      REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      EXTRA_REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/custom-argocd.yaml
+++ b/.github/workflows/custom-argocd.yaml
@@ -62,7 +62,7 @@ jobs:
       image-name: "${{ github.repository_owner }}/custom-argocd"
       registry-username: ${{ github.actor }}
       extra-registry: dhi.io
-      extra-registry-username: ${{ vars.DOCKERHUB_USERNAME }}
+      extra-registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
       context-path: "apps/custom-argocd"
       # The shared workflow scans by default. All 32 fixable HIGH findings are
       # in the argocd binary's own Go dependencies (go-git, x/crypto/ssh,

--- a/.github/workflows/custom-argocd.yaml
+++ b/.github/workflows/custom-argocd.yaml
@@ -51,13 +51,18 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@a75831dcde77fb4ad7caa180497a48fd0be072c4 # v1.0.0
+      packages: write
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1d7be13ba716c8f074a22d26eb8cfa7b032d00e8 # v2.1.0
     with:
       git-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
       tags: "type=raw,value=${{ needs.get-version.outputs.app_version }}"
       build-args: |
         TAG=${{ needs.get-version.outputs.app_version }}
-      image-name: "custom-argocd"
+      registry: ghcr.io
+      image-name: "${{ github.repository_owner }}/custom-argocd"
+      registry-username: ${{ github.actor }}
+      extra-registry: dhi.io
+      extra-registry-username: ${{ vars.DOCKERHUB_USERNAME }}
       context-path: "apps/custom-argocd"
       # The shared workflow scans by default. All 32 fixable HIGH findings are
       # in the argocd binary's own Go dependencies (go-git, x/crypto/ssh,
@@ -66,4 +71,6 @@ jobs:
       scan: false
       # Pull requests validate the build only; publishing happens on push to main.
       push: ${{ github.event_name != 'pull_request' }}
-    secrets: inherit
+    secrets:
+      REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      EXTRA_REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/restore-build.yaml
+++ b/.github/workflows/restore-build.yaml
@@ -38,7 +38,7 @@ jobs:
       image-name: "${{ github.repository_owner }}/vw-restore"
       registry-username: ${{ github.actor }}
       extra-registry: dhi.io
-      extra-registry-username: ${{ vars.DOCKERHUB_USERNAME }}
+      extra-registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
       context-path: "apps/vaultwarden/restore"
       # Same as backup-build.yaml: the only findings are inside the rclone
       # binary copied from rclone/rclone, in rclone's own Go dependencies.

--- a/.github/workflows/restore-build.yaml
+++ b/.github/workflows/restore-build.yaml
@@ -21,22 +21,29 @@ jobs:
     with:
       tag-prefix: "vw-restore-"
   restore-build-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@a75831dcde77fb4ad7caa180497a48fd0be072c4 # v1.0.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1d7be13ba716c8f074a22d26eb8cfa7b032d00e8 # v2.1.0
     needs: get-tag
     permissions:
       contents: read
       id-token: write
       attestations: write
       artifact-metadata: write
+      packages: write
     with:
       # A pull request must build its own head, not the last released tag,
       # or the Dockerfile change under review is never actually exercised.
       git-ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || needs.get-tag.outputs.git_tag }}
       tags: "type=raw,value=${{ needs.get-tag.outputs.docker_tag }}"
-      image-name: "vw-restore"
+      registry: ghcr.io
+      image-name: "${{ github.repository_owner }}/vw-restore"
+      registry-username: ${{ github.actor }}
+      extra-registry: dhi.io
+      extra-registry-username: ${{ vars.DOCKERHUB_USERNAME }}
       context-path: "apps/vaultwarden/restore"
       # Same as backup-build.yaml: the only findings are inside the rclone
       # binary copied from rclone/rclone, in rclone's own Go dependencies.
       scan: false
       push: ${{ github.event_name != 'pull_request' }}
-    secrets: inherit
+    secrets:
+      REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      EXTRA_REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.sec.baseline
+++ b/.sec.baseline
@@ -138,37 +138,6 @@
       ]
     }
   ],
-  "results": {
-    ".github/workflows/backup-build.yaml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/backup-build.yaml",
-        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
-        "is_verified": false,
-        "line_number": 45,
-        "is_secret": false
-      }
-    ],
-    ".github/workflows/custom-argocd.yaml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/custom-argocd.yaml",
-        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
-        "is_verified": false,
-        "line_number": 69,
-        "is_secret": false
-      }
-    ],
-    ".github/workflows/restore-build.yaml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/restore-build.yaml",
-        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
-        "is_verified": false,
-        "line_number": 42,
-        "is_secret": false
-      }
-    ]
-  },
-  "generated_at": "2026-07-31T05:03:23Z"
+  "results": {},
+  "generated_at": "2026-08-01T07:23:38Z"
 }


### PR DESCRIPTION
Moves `vw-backup`, `vw-restore` and `custom-argocd` to GHCR and onto
[v2.1.0](https://github.com/theadzik/github-workflows/releases/tag/v2.1.0) of the shared
workflow. Supersedes #331.

## Why

The Docker Hub account sits at **zero pull quota, permanently** — a probe read `0 remaining`
eleven hours apart on a one-hour window, using a token minted from the account's own
credentials. Image Updater reconciling 20 images every ~2 minutes plus Kyverno re-verifying
every `theadzik/*` pod consumes the 200/hour as fast as it refills.

That is what fails these builds at `Sign image`, and it is the same reason Kyverno reports
`429` for every image it checks. GHCR has no pull rate limits for public images.

## What changed

```yaml
permissions:
  packages: write          # new, and mandatory
with:
  registry: ghcr.io
  image-name: ${{ github.repository_owner }}/vw-backup
  registry-username: ${{ github.actor }}
  extra-registry: dhi.io
  extra-registry-username: ${{ vars.DOCKERHUB_USERNAME }}
secrets:
  REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
  EXTRA_REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
```

v2 takes every registry detail from the caller — the namespace moved out of the login user
and into `image-name`, and `dhi.io` keeps its own credentials since base images still come
from there. A caller that omits `packages: write` fails at startup rather than at the push,
which is the breaking part of v2.

`scan: false` stays on all three: the findings are inside the `rclone` and `argocd`
binaries copied from upstream images, so nothing in these Dockerfiles can action them.

## This only covers the build side

The cluster still pulls from Docker Hub. Manifests, the pull secret, Image Updater and the
Kyverno policy are tracked separately and land after these images exist in GHCR. Until
then the running workloads are unaffected — they keep their current images and simply stop
receiving updates.

The new GHCR packages inherit this repository's visibility, so they are public on first
push and anonymously pullable — verified against the blog image with a `docker pull` from
an empty credential store. No pull secret is needed for them, and nothing needs flipping by
hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)