### PR TITLE
ci: pin the shared workflow to v2.2.0 (CycloneDX SBOM)

### DIFF
--- a/.github/workflows/backup-build.yaml
+++ b/.github/workflows/backup-build.yaml
@@ -21,7 +21,7 @@ jobs:
     with:
       tag-prefix: "vw-backup-"
   backup-build-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1d7be13ba716c8f074a22d26eb8cfa7b032d00e8 # v2.1.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@59202524db1536b7e91d4c8a9e16e9de15f1ab24 # v2.2.0
     needs: get-tag
     permissions:
       contents: read

--- a/.github/workflows/custom-argocd.yaml
+++ b/.github/workflows/custom-argocd.yaml
@@ -52,7 +52,7 @@ jobs:
       attestations: write
       artifact-metadata: write
       packages: write
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1d7be13ba716c8f074a22d26eb8cfa7b032d00e8 # v2.1.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@59202524db1536b7e91d4c8a9e16e9de15f1ab24 # v2.2.0
     with:
       git-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
       tags: "type=raw,value=${{ needs.get-version.outputs.app_version }}"

--- a/.github/workflows/restore-build.yaml
+++ b/.github/workflows/restore-build.yaml
@@ -21,7 +21,7 @@ jobs:
     with:
       tag-prefix: "vw-restore-"
   restore-build-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1d7be13ba716c8f074a22d26eb8cfa7b032d00e8 # v2.1.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@59202524db1536b7e91d4c8a9e16e9de15f1ab24 # v2.2.0
     needs: get-tag
     permissions:
       contents: read


### PR DESCRIPTION
Picks up [github-workflows#2](https://github.com/theadzik/github-workflows/pull/2): the SBOM is now generated by syft as CycloneDX rather than by BuildKit as SPDX.

## Why

Trivy could not read the SPDX SBOMs we publish. It reported **zero** OS packages rather than an error — syft's SPDX writer emits no `OPERATING-SYSTEM` package, and Trivy's parser needs one to establish distro context. syft's CycloneDX writer declares the OS; both Trivy and Grype read it.

Validated end to end on the blog before release: predicate type `https://cyclonedx.org/bom`, `cosign verify-attestation` passes against the policy's signer identity, and `trivy sbom` reads 12 OS packages where it read 0.

## Deliberately not in this PR

**The Kyverno policy still matches `https://spdx.dev/Document/v2.3`.** Switching it here would fail SBOM verification for every image that has not yet been rebuilt, which is all of them at merge time. Order is:

1. this PR — merging rebuilds `custom-argocd` automatically via its path filter
2. dispatch `vw-backup-build` and `vw-restore-build` (their push trigger is tags only)
3. blog PR [#123](https://github.com/theadzik/blog/pull/123)
4. verify all four images carry a CycloneDX attestation
5. follow-up PR switching `intoto.type` to `https://cyclonedx.org/bom`

The policy is `Audit` with `failurePolicy: Ignore` throughout, so the intervening window degrades PolicyReports rather than blocking pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)