### PR TITLE
fix(kyverno): accept the CycloneDX SBOM predicate

### DIFF
--- a/kubernetes/kustomizations/kyverno/validate-image-attestations.yaml
+++ b/kubernetes/kustomizations/kyverno/validate-image-attestations.yaml
@@ -40,7 +40,15 @@ spec:
         ctlog:
           url: https://rekor.sigstore.dev
   attestations:
-    - name: sbom
+    - name: sbom_cyclonedx
+      intoto:
+        type: "https://cyclonedx.org/bom"
+    # Transitional. Images published before github-workflows v2.2.0 carry an
+    # SPDX SBOM instead. Drop this entry and the `||` branch below once no
+    # running image predates it - as of this change that is blog prod
+    # (2026.8.1) and blog dev (sha-9742a89), both of which move to CycloneDX at
+    # their next build. The vaultwarden and argocd images are already there.
+    - name: sbom_spdx
       intoto:
         type: "https://spdx.dev/Document/v2.3"
     - name: provenance
@@ -56,10 +64,13 @@ spec:
           verifyImageSignatures(image, [attestors.cosign])
         ).all(e, e > 0)
       message: Failed to verify image signature
+    # CEL `||` short-circuits, so an image carrying the current format costs one
+    # attestation fetch; only a pre-v2.2.0 image pays for the second.
     - expression: >-
-        (images.containers + images.initContainers + images.ephemeralContainers).map(image,
-          verifyAttestationSignatures(image, attestations.sbom, [attestors.cosign])
-        ).all(e, e > 0)
+        (images.containers + images.initContainers + images.ephemeralContainers).all(image,
+          verifyAttestationSignatures(image, attestations.sbom_cyclonedx, [attestors.cosign]) > 0
+          || verifyAttestationSignatures(image, attestations.sbom_spdx, [attestors.cosign]) > 0
+        )
       message: "Failed to verify SBOM attestation signature"
     - expression: >-
         (images.containers + images.initContainers + images.ephemeralContainers).map(image,


### PR DESCRIPTION
Follow-up to #342. The shared workflow now publishes the SBOM as CycloneDX, so the policy's SPDX-only `intoto.type` matches nothing built on v2.2.0.

## State of the four images

All four were rebuilt on v2.2.0 and verified directly against the registry:

| Image | SBOM predicate |
| --- | --- |
| `vw-backup:2026.7.1` | `https://cyclonedx.org/bom` |
| `vw-restore:2026.7.1` | `https://cyclonedx.org/bom` |
| `custom-argocd:v3.4.6` | `https://cyclonedx.org/bom` |
| `zmuda-pro-blog:main` | `https://spdx.dev/Document/v2.3` |

The blog is the exception on purpose. Its `build.yaml` path filter deliberately excludes workflow files, so merging #342 did not rebuild it — and the two blog images actually running, prod `2026.8.1` and dev `sha-9742a89`, are released artifacts. Republishing either would repoint a tag that is contractually immutable, which is exactly the failure this repo's push-by-digest ordering exists to prevent.

## So both predicates are accepted, transitionally

```
verifyAttestationSignatures(image, attestations.sbom_cyclonedx, ...) > 0
|| verifyAttestationSignatures(image, attestations.sbom_spdx, ...) > 0
```

CEL `||` short-circuits, so a current image costs one attestation fetch and only a pre-v2.2.0 image pays for the second. That matters here: admission latency is already the reason this policy runs `Audit` instead of `Deny`.

The comment in the file names the exact removal condition — drop the SPDX entry once neither blog image predates v2.2.0.

## One thing this PR does not know yet

Whether `verifyAttestationSignatures` **returns 0** for a missing predicate type or **raises an evaluation error**. Kyverno's docs do not say, and it decides whether the `||` actually works. Verifying against live PolicyReports after this syncs, since `Audit` + `failurePolicy: Ignore` makes that a free experiment. If it errors, the fallback is two separate policies rather than one expression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)