### PR TITLE
feat: cilium network policy

### DIFF
--- a/charts/media-stack/Chart.yaml
+++ b/charts/media-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: media-stack
 description: A Helm chart for media services (Jellyfin, Radarr, Sonarr, Bazarr, NZBGet)
 type: application
-version: 3.1.0
+version: 4.0.0
 appVersion: "1.0.0"
 kubeVersion: ">=1.28.0-0"
 keywords:

--- a/charts/media-stack/README.md
+++ b/charts/media-stack/README.md
@@ -40,8 +40,7 @@ These components are optional but enable additional features:
    - Chart supports any ingress controller compatible with `networking.k8s.io/v1`
 
 2. **Network Policy Support**
-   - Standard NetworkPolicy: Built into most CNI plugins (Calico, Cilium, Weave)
-   - CiliumNetworkPolicy: Requires Cilium CNI (`networkPolicy.type: CiliumNetworkPolicy`)
+   - Requires Cilium CNI when `networkPolicy.enabled: true`
    - Optional but recommended for network segmentation
 
 3. **Vertical Pod Autoscaler (VPA)** (if `vpa.enabled: true`)
@@ -66,7 +65,6 @@ These components are optional but enable additional features:
 | StatefulSet           | apps/v1                   | 1.9+ (GA)                       |
 | Service               | v1                        | All versions                    |
 | Ingress               | networking.k8s.io/v1      | 1.19+ (GA)                      |
-| NetworkPolicy         | networking.k8s.io/v1      | 1.7+ (GA)                       |
 | CiliumNetworkPolicy   | cilium.io/v2              | Requires Cilium CNI             |
 | VPA                   | autoscaling.k8s.io/v1     | 1.28+ (requires VPA controller) |
 | ResourceClaimTemplate | resource.k8s.io/v1        | 1.34+ (GA)                      |
@@ -196,12 +194,12 @@ Service-specific labels are rendered after global labels. If the same key is set
 
 ### Network Policy
 
-- **Ingress**: Allows pod-to-pod communication within namespace and traffic from Traefik
-- **Egress**: Allows all outbound traffic by default (configurable)
-- **Type**: Standard Kubernetes NetworkPolicy or CiliumNetworkPolicy
-- **Configuration**: Set via `networkPolicy.ingress` and `networkPolicy.egress` lists
+- **Ingress**: Allows traffic from the release namespace and any namespace listed in `networkPolicy.ingressNamespaces`
+- **Egress**: Allows DNS to kube-dns and all outbound traffic
+- **Type**: CiliumNetworkPolicy only
+- **Configuration**: Set via `networkPolicy.ingressNamespaces`
 - **Disable**: Set `networkPolicy.enabled: false` to remove network segmentation
-- **Selector**: Uses component labels (`app.kubernetes.io/component`)
+- **Selector**: Uses `app.kubernetes.io/name`, `app.kubernetes.io/instance`, and `app.kubernetes.io/part-of`
 
 ### Storage
 
@@ -280,7 +278,7 @@ media/
 ├── templates/
 │   ├── _helpers.tpl        # Template helpers for labels and names
 │   ├── namespace.yaml      # Namespace and annotations
-│   ├── networkpolicy.yaml  # NetworkPolicy or CiliumNetworkPolicy
+│   ├── networkpolicy.yaml  # CiliumNetworkPolicy resources
 │   ├── pvc.yaml            # All PersistentVolumeClaims
 │   ├── secrets.yaml        # Service secrets
 │   ├── statefulset.yaml    # All StatefulSets
@@ -319,11 +317,17 @@ All resources are labeled following [Helm best practices](https://helm.sh/docs/c
 
 - `app.kubernetes.io/component: <service-name>` - Component (jellyfin, radarr, etc.)
 
-**Selector labels** (used by Services, Ingress, NetworkPolicy):
+**Selector labels** (used by Services and Ingress):
 
 - `app.kubernetes.io/name: media-stack`
 - `app.kubernetes.io/instance: <release-name>`
 - `app.kubernetes.io/component: <service-name>`
+
+**CiliumNetworkPolicy endpoint selector labels**:
+
+- `app.kubernetes.io/name: <service-name>`
+- `app.kubernetes.io/instance: <release-name>`
+- `app.kubernetes.io/part-of: media-stack`
 
 **Label helpers**: Use template helpers from `_helpers.tpl`:
 
@@ -358,8 +362,7 @@ All resources are labeled following [Helm best practices](https://helm.sh/docs/c
 
 **NetworkPolicy not enforcing?**
 
-- Verify CNI supports NetworkPolicy: Check your CNI plugin documentation
-- For CiliumNetworkPolicy: Ensure Cilium CNI is installed and running
+- Ensure Cilium CNI is installed and running
 - Test with `networkPolicy.enabled: false` to isolate the issue
 
 **VPA not adjusting resources?**

--- a/charts/media-stack/templates/networkpolicy.yaml
+++ b/charts/media-stack/templates/networkpolicy.yaml
@@ -1,33 +1,53 @@
 {{- if .Values.networkPolicy.enabled }}
+{{- $stack := include "media-stack.name" . }}
+{{- $ingressNamespaces := .Values.networkPolicy.ingressNamespaces | default (list) }}
+{{- $fromNamespaces := concat (list .Release.Namespace) $ingressNamespaces | uniq }}
+{{- range $svcName, $svc := .Values.services }}
+{{- if $svc.enabled }}
 ---
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
 metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ printf "%s-%s-netpol" $svcName $.Release.Name | trunc 63 | trimSuffix "-" }}
+  namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "media-stack.labels" . | nindent 4 }}
+    {{- include "media-stack.componentLabels" (dict "component" $svcName "context" $) | nindent 4 }}
 spec:
-  podSelector: {}
-  policyTypes:
-    - Ingress
-    - Egress
-  {{- if hasKey .Values.networkPolicy "ingress" }}
+  description: >-
+    {{ $svcName }}: ingress only from the media stack itself{{ if $ingressNamespaces }} and
+    {{ join ", " $ingressNamespaces }}{{ end }}; egress unrestricted.
+  endpointSelector:
+    matchLabels:
+      "k8s:app.kubernetes.io/name": {{ $svcName | quote }}
+      "k8s:app.kubernetes.io/instance": {{ $.Release.Name | quote }}
+      "k8s:app.kubernetes.io/part-of": {{ $stack | quote }}
   ingress:
-    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
-  {{- else }}
-  # Default: allow ingress from pods in the same namespace
-  ingress:
-    - from:
-        - podSelector: {}
-  {{- end }}
-  {{- if hasKey .Values.networkPolicy "egress" }}
+    - fromEndpoints:
+        {{- range $ns := $fromNamespaces }}
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": {{ $ns | quote }}
+        {{- end }}
+      toPorts:
+        - ports:
+            - port: {{ $svc.port | quote }}
+              protocol: TCP
   egress:
-    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
-  {{- else }}
-  # Default: allow egress everywhere (pods contact open internet)
-  egress:
-    - to:
-        - namespaceSelector: {}
-  {{- end }}
+    # Stated explicitly so that narrowing the rule below to `world` later does
+    # not silently break name resolution.
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": kube-system
+            "k8s:k8s-app": kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # Indexers, usenet providers, metadata and subtitle APIs all live on the
+    # public internet, so egress stays open.
+    - toEntities:
+        - all
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/media-stack/values.yaml
+++ b/charts/media-stack/values.yaml
@@ -3,28 +3,9 @@ namespaceAnnotations: {}
 
 networkPolicy:
   enabled: false
-  ingress:
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: traefik
-      ports:
-        - protocol: TCP
-    - from:
-        - podSelector: {}
-
-  egress:
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
-      ports:
-        - protocol: UDP
-          port: 53
-    - to:
-        - podSelector: {}
-    - to:
-        - namespaceSelector: {}
+  # Namespaces outside the stack allowed to reach the services.
+  ingressNamespaces: []
+  # - traefik
 
 # Global ingress annotations (applied to all ingresses)
 ingressAnnotations: {}

--- a/kubernetes/helm/media/values.yaml
+++ b/kubernetes/helm/media/values.yaml
@@ -1,14 +1,9 @@
 namespaceAnnotations:
   argocd.argoproj.io/sync-options: Delete=false,Prune=false
 networkPolicy:
-  enabled: false
-  ingress:
-  - from:
-    - podSelector: {}
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: traefik
+  enabled: true
+  ingressNamespaces:
+    - traefik
 ingressClassName: traefik
 ingressAnnotations:
   cert-manager.io/cluster-issuer: lets-encrypt-prod
@@ -24,7 +19,7 @@ persistentVolumeClaims:
   downloads:
     enabled: true
     accessModes:
-    - ReadWriteMany
+      - ReadWriteMany
     storage: 7Ti
     storageClassName: synology-nfs-retain
     annotations:
@@ -41,11 +36,11 @@ resourceClaimTemplate:
   spec:
     devices:
       requests:
-      - name: i915
-        exactly:
-          deviceClassName: gpu.intel.com
-          allocationMode: ExactCount
-          count: 1
+        - name: i915
+          exactly:
+            deviceClassName: gpu.intel.com
+            allocationMode: ExactCount
+            count: 1
 services:
   jellyfin:
     enabled: true
@@ -65,7 +60,7 @@ services:
         storage: 10Gi
         storageClassName: synology-iscsi-retain-ssd
         accessModes:
-        - ReadWriteOnce
+          - ReadWriteOnce
         annotations:
           argocd.argoproj.io/sync-options: Delete=false,Prune=false
         labels:
@@ -109,7 +104,7 @@ services:
         storage: 2Gi
         storageClassName: synology-iscsi-retain-ssd
         accessModes:
-        - ReadWriteOnce
+          - ReadWriteOnce
         annotations:
           argocd.argoproj.io/sync-options: Delete=false,Prune=false
         labels:
@@ -149,7 +144,7 @@ services:
         storage: 2Gi
         storageClassName: synology-iscsi-retain-ssd
         accessModes:
-        - ReadWriteOnce
+          - ReadWriteOnce
         annotations:
           argocd.argoproj.io/sync-options: Delete=false,Prune=false
         labels:
@@ -189,7 +184,7 @@ services:
         storage: 2Gi
         storageClassName: synology-iscsi-retain-ssd
         accessModes:
-        - ReadWriteOnce
+          - ReadWriteOnce
         annotations:
           argocd.argoproj.io/sync-options: Delete=false,Prune=false
         labels:
@@ -230,7 +225,7 @@ services:
         storage: 5Gi
         storageClassName: synology-iscsi-retain-ssd
         accessModes:
-        - ReadWriteOnce
+          - ReadWriteOnce
         annotations:
           argocd.argoproj.io/sync-options: Delete=false,Prune=false
         labels:
@@ -240,7 +235,7 @@ services:
         storage: 128Gi
         storageClassName: synology-iscsi-delete-ssd
         accessModes:
-        - ReadWriteOnce
+          - ReadWriteOnce
         annotations:
           argocd.argoproj.io/sync-options: Delete=false,Prune=false
     existingSecretName: nzbget-secret


### PR DESCRIPTION
This pull request updates the network policy implementation for the media stack Helm chart, switching from standard Kubernetes `NetworkPolicy` to Cilium's `CiliumNetworkPolicy` for more expressive and granular control. It also simplifies and centralizes configuration of allowed ingress namespaces. The most important changes are:

**Network Policy Implementation:**

* Replaces Kubernetes `NetworkPolicy` resources with `CiliumNetworkPolicy` resources in `networkpolicy.yaml`, enabling advanced policy features and more precise control over ingress and egress traffic.
* Updates the policy to restrict ingress to only the media stack's own namespace and any explicitly listed namespaces, while keeping egress mostly unrestricted but explicitly allowing DNS traffic to `kube-dns`.

**Configuration Simplification:**

* Removes the complex `ingress` and `egress` arrays from `values.yaml` and introduces a simpler `ingressNamespaces` list for specifying which external namespaces are allowed ingress.
* Updates the example values in `kubernetes/helm/media/values.yaml` to enable network policies by default and allow ingress from the `traefik` namespace via the new `ingressNamespaces` field.